### PR TITLE
Eliminate "warning: assigned but unused variable - e"

### DIFF
--- a/lib/ffi-ncurses/mouse.rb
+++ b/lib/ffi-ncurses/mouse.rb
@@ -137,7 +137,7 @@ module FFI
       functions.each do |function|
         begin
           attach_function(*function)
-        rescue Object => e
+        rescue Object
           (@unattached_functions ||= []) << function
         end
       end


### PR DESCRIPTION
Ruby warns "duplicated when clause is ignored" because the `e` object is not used anywhere.
